### PR TITLE
fix: Secure filament routes with authentication

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -89,10 +89,19 @@ GET /api/auth/me
 
 ### 📦 Filaments (Protected)
 
+**Authentication Required**: All filament endpoints require authentication via HttpOnly cookies or Bearer token. Unauthenticated requests will receive a `401 Unauthorized` response.
+
+**User Isolation**: Each user can only access, create, update, and delete their own filaments. Requests return data scoped to the authenticated user's ID.
+
 #### Get All Filaments
 ```http
 GET /api/filaments
+Authorization: Bearer YOUR_ACCESS_TOKEN
+# OR use HttpOnly cookies (automatically sent by browser)
 ```
+
+**Error Responses:**
+- `401 Unauthorized` - Missing or invalid authentication token
 
 **Response:**
 ```json
@@ -203,10 +212,17 @@ DELETE /api/notes/:id
 
 ### 📊 Analytics (Protected)
 
+**Authentication Required**: All analytics endpoints require authentication. Returns statistics for the authenticated user's filaments only.
+
 #### Get Total Filament Count
 ```http
 GET /api/filaments/stats/total
+Authorization: Bearer YOUR_ACCESS_TOKEN
+# OR use HttpOnly cookies (automatically sent by browser)
 ```
+
+**Error Responses:**
+- `401 Unauthorized` - Missing or invalid authentication token
 
 **Response:**
 ```json


### PR DESCRIPTION
## Summary
Fixes #8 - Security: Filaments routes not protected by authentication

## Problem
All filament routes were using a hardcoded `DEFAULT_USER_ID`, allowing unauthenticated users to:
- Access all filaments without logging in
- Create, update, and delete filaments without authentication
- See data from all users (no user isolation)

## Solution
Added authentication middleware (`authenticateToken`) to all filament routes and replaced `DEFAULT_USER_ID` with the authenticated user's ID (`req.user!.id`).

## Changes
- **Backend** (`backend/src/routes/filaments.ts`):
  - Added `authenticateToken` middleware to all 9 filament routes:
    - GET `/api/filaments` - Get all filaments
    - GET `/api/filaments/:id` - Get filament by ID
    - POST `/api/filaments` - Create filament
    - PUT `/api/filaments/:id` - Update filament
    - DELETE `/api/filaments/:id` - Delete filament
    - PATCH `/api/filaments/:id/reduce` - Reduce filament amount
    - GET `/api/filaments/stats/total` - Get total count
    - GET `/api/filaments/stats/value` - Get total value
    - GET `/api/filaments/stats/brands` - Get brand stats
  - Replaced all instances of `DEFAULT_USER_ID` with `req.user!.id`
  - Removed `DEFAULT_USER_ID` constant
  - Updated Swagger documentation with `security: [cookieAuth: []]` and 401 responses

- **Documentation** (`docs/API.md`):
  - Added explicit authentication requirements section for filament endpoints
  - Clarified that unauthenticated requests return 401
  - Added note about user data isolation

## Testing
- [x] All routes require authentication (tested with unauthenticated requests)
- [x] Each user can only access their own filaments
- [x] Frontend continues to work (already has `withCredentials: true`)
- [x] Swagger documentation updated

## Security Impact
- **Before**: Critical vulnerability - anyone could access/modify any user's filaments
- **After**: All routes properly protected, user data isolated

Fixes #8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Secure all filament and analytics endpoints with authentication, scope data to the authenticated user, and update Swagger/API docs accordingly.
> 
> - **Backend**:
>   - Protect all `backend/src/routes/filaments.ts` routes with `authenticateToken`.
>   - Scope DB operations to the authenticated user (`req.user!.id`) and remove `DEFAULT_USER_ID`.
>   - Update Swagger docs: add `security: [cookieAuth]`, include `401` responses, and clarify user-scoped descriptions.
> - **Docs**:
>   - `docs/API.md`: document authentication requirements and user isolation for Filaments and Analytics; add Authorization examples and `401` error notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24e8c629efdc066e6c6f54ed11e0d3ae656c1183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->